### PR TITLE
Fix add buttons on list pages

### DIFF
--- a/src/views/DashboardList.vue
+++ b/src/views/DashboardList.vue
@@ -1,14 +1,10 @@
 <template>
     <div>
-        <div class="row border-bottom border-primary p-2">
-            <div class="col-md-10">
-                <h2 class="title text-primary">{{$tc('titles.dashboard', 2)}}</h2>
-            </div>
-            <div class="col-md-2 pull-right text-right">
-                <a href="#/dashboards/add" class="btn btn-primary btn-sm" role="button">
-                    <font-awesome-icon icon="plus" size="1x"></font-awesome-icon>  {{$t('actions.add', {type: $tc('titles.dashboard').toLowerCase()})}}
-                </a>
-            </div>
+        <div class="row border-bottom border-primary p-3 d-flex justify-content-between">
+            <h2 class="title text-primary">{{$tc('titles.dashboard', 2)}}</h2>
+            <a href="#/dashboards/add" class="btn btn-primary btn-sm" role="button">
+                <font-awesome-icon icon="plus" size="1x"></font-awesome-icon>  {{$t('actions.add', {type: $tc('titles.dashboard').toLowerCase()})}}
+            </a>
         </div>
         <div class="row">
             <div class="col-md-12">

--- a/src/views/DataSourceList.vue
+++ b/src/views/DataSourceList.vue
@@ -1,15 +1,11 @@
 <template>
     <div>
-        <div class="row border-bottom border-primary p-2">
-            <div class="col-md-8">
-                <h2 class="title text-primary">{{$tc('titles.dataSource', 2)}}</h2>
-            </div>
-            <div class="col-md-4 pull-right">
-                <router-link :to="{name: 'addDataSource'}" class="btn btn-primary btn-sm">
-                    <font-awesome-icon icon="plus" size="1x"></font-awesome-icon> {{$t('actions.add', {type:
-                    $tc('titles.dataSource').toLowerCase()})}}
-                </router-link>
-            </div>
+        <div class="row border-bottom border-primary p-3 d-flex justify-content-between">
+            <h2 class="title text-primary">{{$tc('titles.dataSource', 2)}}</h2>
+            <router-link :to="{name: 'addDataSource'}" class="btn btn-primary btn-sm">
+                <font-awesome-icon icon="plus" size="1x"></font-awesome-icon> {{$t('actions.add', {type:
+                $tc('titles.dataSource').toLowerCase()})}}
+            </router-link>
         </div>
         <div class="row">
             <div class="col-md-12">

--- a/src/views/WorkflowList.vue
+++ b/src/views/WorkflowList.vue
@@ -1,15 +1,11 @@
 <template>
     <div>
-        <div class="row border-bottom border-primary p-2">
-            <div class="col-md-8">
-                <h2 class="title text-primary">{{$tc('titles.workflow', 2)}}</h2>
-            </div>
-            <div class="col-md-4 pull-right text-right">
-                <a href="#/workflows/add" class="btn btn-primary btn-sm" role="button">
-                    <font-awesome-icon icon="plus" size="1x"></font-awesome-icon> {{$t('actions.add', {type:
-                    $tc('titles.workflow').toLowerCase()})}}
-                </a>
-            </div>
+        <div class="row border-bottom border-primary p-3 d-flex justify-content-between">
+            <h2 class="title text-primary">{{$tc('titles.workflow', 2)}}</h2>
+            <a href="#/workflows/add" class="btn btn-primary btn-sm" role="button">
+                <font-awesome-icon icon="plus" size="1x"></font-awesome-icon> {{$t('actions.add', {type:
+                $tc('titles.workflow').toLowerCase()})}}
+            </a>
         </div>
         <div class="row">
             <div class="col-md-12">


### PR DESCRIPTION
The pull-right and pull-left classes no longer work in Bootstrap v4 because they were removed. ([reference](https://pt.stackoverflow.com/a/252273))