### PR TITLE
Add type to scatter visualization - fix #43

### DIFF
--- a/src/components/caipirinha-visualization/CaipirinhaVisualizationScatter.vue
+++ b/src/components/caipirinha-visualization/CaipirinhaVisualizationScatter.vue
@@ -6,6 +6,25 @@
 export default {
   name: "caipirinha-visualization-scatter",
   props: ["visualizationData"],
+  methods: {
+    getType() {
+      let sample;
+      
+      try {
+        sample = this.visualizationData.data[0].values[0].x;
+      } catch(e) {
+        return 'linear';
+      }  
+      
+      if (isNaN(sample) && !isNaN(Date.parse(sample)))
+        return 'datetime';
+      
+      if (typeof sample == 'string')
+        return 'category';
+
+      return 'linear';
+    }
+  },
   data: function() {
     const options = {
       chart: {
@@ -17,7 +36,8 @@ export default {
       xAxis: {
         title: {
           text: this.visualizationData.x.title
-        }
+        },
+        type: this.getType()
       },
       yAxis: {
         title: {


### PR DESCRIPTION
I solve this issue checking the type of data on axis X instead of looking the value of the field **x -> type** in the response of the Caipirinha API. I did this because, even with x values being strings, the response of Caipirinha API in the field **x -> type** is being **number**.

[Example](https://dev.ctweb.inweb.org.br/caipirinha/visualizations/1785/46c81efe-8b77-4a6d-b5ef-aa28dcb9ed01?token=123456)

Fix #43 