### PR TITLE
Fix bugs in visualization map

### DIFF
--- a/src/components/caipirinha-visualization/CaipirinhaVisualizationMap.vue
+++ b/src/components/caipirinha-visualization/CaipirinhaVisualizationMap.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="height: 500px; padding: 0 5px 5px 0">
+  <div style="height: 100%; padding: 0 5px 5px 0">
     <l-map ref="mapRef">
       <l-tile-layer :url="url"></l-tile-layer>
     </l-map>
@@ -45,22 +45,20 @@ export default {
     this.mode = this.visualizationData.mode;
 
     this.$nextTick(() => {
-      if (this.mode.points) {
-        this.points.slice(0, 100).forEach(point => {      // TODO: Find a way to show larger datasets
+      if (this.mode.points || this.mode == 'points') {
+        this.points.forEach(point => {      // TODO: Find a way to show larger datasets
           L.marker([point.lat, point.lon])
           .addTo(this.$refs.mapRef.mapObject);
         });
-
-        console.log("Attention: The number of markers shown in the map are being limited.")
       }
 
-      if (this.mode.heatmap) {
+      if (this.mode.heat || this.mode.heatmap || this.mode == 'heatmap') {
         L.heatLayer(
-          this.points.map(point => [point.lat, point.lon, 1])
+          this.points.map(point => [point.lat, point.lon, point.value | 1])
         ).addTo(this.$refs.mapRef.mapObject);
       }
       this.$refs.mapRef.mapObject.fitBounds(this.getBounds(this.points))
-      this.$refs.mapRef.mapObject.setView([-15, -50], 3)
+      //this.$refs.mapRef.mapObject.setView([-15, -50], 3)
       
     })
   }

--- a/src/views/JobDetail.vue
+++ b/src/views/JobDetail.vue
@@ -134,9 +134,9 @@
                         </div>
                     </b-tab>
                     <b-tab :title="$tc('job.visualizations', 2)" title-item-class="smalltab" v-if="job.results && job.results.length"
-                        @click="loadVisualizations">
-                        <div class="row" v-for="(result, inx) in job.results" :key="result.id">
-                            <div class="col-md-8 lemonade offset-2" style="margin-top: 14px">
+                        @click="showVisualizations = true">
+                        <div class="row" v-for="result in job.results" :key="result.id">
+                            <div class="col-md-8 lemonade offset-2" style="margin-top: 14px; height: 500px" v-if="showVisualizations">
                                 <caipirinha-visualization :url="getCaipirinhaLink(job.id, result.task.id)"></caipirinha-visualization>
                             </div>
                         </div>
@@ -280,13 +280,11 @@
                 operationsLookup: new Map(),
                 selectedTask: {},
                 showSourceCode: false,
-                showProperties: false
+                showProperties: false,
+                showVisualizations: false,
             }
         },
         methods: {
-            loadVisualizations() {
-
-            },
             getTask(taskId) {
                 return this.tasks[taskId]
             },


### PR DESCRIPTION
@waltersf I saw that u have done some modifications which may have caused some problems in the map visualization. I am basically undoing that, which may be a mistake on my part.

In this commit (https://github.com/eubr-bigsea/citrus/commit/3fe866e888f5470df14b61dabfd2422ad7c8b6e7) you have changed the height of the map to a fixed value.
This can't be set to a fixed value because of the dashboard. It needs to be resizable.

If you have done this **only** to adjust the Visualization tab on the JobDetail page. I solved it putting the height in the parent element.

In the same commit, you have used the `setView` method to a fixed value and I did not understand why. Given that the `fitBounds` method is already used to do the best fit to the data.

--

I did not used the event as you've suggested, but I solved the issue #32.

--

And I noticed that the responses of Caipirinha are not consistent. There are different ways to identify the mode of the map chart. Which caused the problem of the issue #18. But it is solved.