### PR TITLE
Hide diagram-toolbar on execution detail

### DIFF
--- a/src/components/Diagram.vue
+++ b/src/components/Diagram.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="border">
-        <diagram-toolbar :workflow="workflow"></diagram-toolbar>
+        <diagram-toolbar :workflow="workflow" v-if="showToolbar"></diagram-toolbar>
         <div class="lemonade-container not-selectable" id="lemonade-container" :class="{'with-grid': showGrid}"
             v-on:click="diagramClick">
             <VuePerfectScrollbar class="scroll-area" :settings="settings" @ps-scroll-y="scrollHandle">


### PR DESCRIPTION
There was already a props called **showToolbar** on Diagram component.

Can we use it for this purpose? It is also inside the **init()** method, so I am afraid of side effects.

Fix #73 